### PR TITLE
Add error message for unsupported types on EnterPaymentInfoDialog

### DIFF
--- a/lib/app_de.arb
+++ b/lib/app_de.arb
@@ -406,6 +406,7 @@
   "payment_info_dialog_hint_expanded": "Gib eine Rechnung, eine Node-ID oder eine Lightning-Adresse ein.",
   "payment_info_dialog_barcode": "Barcode scannen",
   "payment_info_dialog_error": "Ungültige Rechnung, ID oder Adresse",
+  "payment_info_dialog_error_unsupported_input": "Unsupported input",
   "payment_info_dialog_error_qrcode": "QR-Code wurde nicht erkannt.",
   "payment_info_dialog_action_cancel": "ABBRECHEN",
   "payment_info_dialog_action_approve": "BESTÄTIGEN",

--- a/lib/app_el.arb
+++ b/lib/app_el.arb
@@ -406,6 +406,7 @@
   "payment_info_dialog_hint_expanded": "Enter an invoice, a node ID or a Lightning address.",
   "payment_info_dialog_barcode": "Scan Barcode",
   "payment_info_dialog_error": "Invalid invoice, ID or Address",
+  "payment_info_dialog_error_unsupported_input": "Unsupported input",
   "payment_info_dialog_error_qrcode": "QR code wasn't detected.",
   "payment_info_dialog_action_cancel": "CANCEL",
   "payment_info_dialog_action_approve": "APPROVE",

--- a/lib/app_el.arb
+++ b/lib/app_el.arb
@@ -1892,7 +1892,7 @@
       }
     }
   },
-  "lnurl_error_unsupported": "Unsupported LNUrl",
+  "lnurl_error_unsupported": "Unsupported LNURL",
   "make_invoice_request_title": "This site wants to pay you:",
   "make_invoice_request_action_cancel": "CANCEL",
   "make_invoice_request_action_approve": "APPROVE",

--- a/lib/app_en.arb
+++ b/lib/app_en.arb
@@ -406,6 +406,7 @@
   "payment_info_dialog_hint_expanded": "Enter an invoice, a node ID or a Lightning address.",
   "payment_info_dialog_barcode": "Scan Barcode",
   "payment_info_dialog_error": "Invalid invoice, ID or Address",
+  "payment_info_dialog_error_unsupported_input": "Unsupported input",
   "payment_info_dialog_error_qrcode": "QR code wasn't detected.",
   "payment_info_dialog_action_cancel": "CANCEL",
   "payment_info_dialog_action_approve": "APPROVE",

--- a/lib/app_en.arb
+++ b/lib/app_en.arb
@@ -1892,7 +1892,7 @@
       }
     }
   },
-  "lnurl_error_unsupported": "Unsupported LNUrl",
+  "lnurl_error_unsupported": "Unsupported LNURL",
   "make_invoice_request_title": "This site wants to pay you:",
   "make_invoice_request_action_cancel": "CANCEL",
   "make_invoice_request_action_approve": "APPROVE",

--- a/lib/app_es.arb
+++ b/lib/app_es.arb
@@ -1892,7 +1892,7 @@
       }
     }
   },
-  "lnurl_error_unsupported": "LNUrl no compatible",
+  "lnurl_error_unsupported": "LNURL no compatible",
   "make_invoice_request_title": "Este sitio quiere pagarte:",
   "make_invoice_request_action_cancel": "CANCELAR",
   "make_invoice_request_action_approve": "APROBAR",

--- a/lib/app_es.arb
+++ b/lib/app_es.arb
@@ -406,6 +406,7 @@
   "payment_info_dialog_hint_expanded": "Ingrese una factura, ID de nodo o dirección Lightning.",
   "payment_info_dialog_barcode": "Escanear código de barras",
   "payment_info_dialog_error": "Factura, ID o dirección incorrecta.",
+  "payment_info_dialog_error_unsupported_input": "Unsupported input",
   "payment_info_dialog_error_qrcode": "No se detectó el código QR.",
   "payment_info_dialog_action_cancel": "CANCELAR",
   "payment_info_dialog_action_approve": "APROBAR",

--- a/lib/app_fi.arb
+++ b/lib/app_fi.arb
@@ -1892,7 +1892,7 @@
       }
     }
   },
-  "lnurl_error_unsupported": "LNUrl muoto ei ole tuettu",
+  "lnurl_error_unsupported": "LNURL muoto ei ole tuettu",
   "make_invoice_request_title": "Sivusto haluaa maksaa sinulle:",
   "make_invoice_request_action_cancel": "Peruuta",
   "make_invoice_request_action_approve": "HYVÄKSY",

--- a/lib/app_fi.arb
+++ b/lib/app_fi.arb
@@ -406,6 +406,7 @@
   "payment_info_dialog_hint_expanded": "Syötä LN-lasku, solmu- tai Lightning-osoite.",
   "payment_info_dialog_barcode": "Lue viivakoodi",
   "payment_info_dialog_error": "LN-lasku, solmu- tai Lightning-osoite oli virheellinen.",
+  "payment_info_dialog_error_unsupported_input": "Unsupported input",
   "payment_info_dialog_error_qrcode": "QR-koodia ei tunnistettu.",
   "payment_info_dialog_action_cancel": "Peruuta",
   "payment_info_dialog_action_approve": "HYVÄKSY",

--- a/lib/app_fr.arb
+++ b/lib/app_fr.arb
@@ -1892,7 +1892,7 @@
       }
     }
   },
-  "lnurl_error_unsupported": "LNUrl non supporté",
+  "lnurl_error_unsupported": "LNURL non supporté",
   "make_invoice_request_title": "Ce site veut vous payer :",
   "make_invoice_request_action_cancel": "ANNULER",
   "make_invoice_request_action_approve": "APPROUVER",

--- a/lib/app_fr.arb
+++ b/lib/app_fr.arb
@@ -406,6 +406,7 @@
   "payment_info_dialog_hint_expanded": "Entrez une facture, un ID de noeud ou une adresse Lightning.",
   "payment_info_dialog_barcode": "Scanner le code-barres",
   "payment_info_dialog_error": "Facture, ID ou adresse non valide",
+  "payment_info_dialog_error_unsupported_input": "Unsupported input",
   "payment_info_dialog_error_qrcode": "Le code QR n'a pas été détecté.",
   "payment_info_dialog_action_cancel": "ANNULER",
   "payment_info_dialog_action_approve": "APPROUVER",

--- a/lib/app_it.arb
+++ b/lib/app_it.arb
@@ -406,6 +406,7 @@
   "payment_info_dialog_hint_expanded": "Inserisci una invoice, l'ID di un nodo o un Lightning Address",
   "payment_info_dialog_barcode": "Scansiona il barcode",
   "payment_info_dialog_error": "Invoice, ID or indirizzo non valido",
+  "payment_info_dialog_error_unsupported_input": "Unsupported input",
   "payment_info_dialog_error_qrcode": "Nessun QR code rilevato.",
   "payment_info_dialog_action_cancel": "CANCELLA",
   "payment_info_dialog_action_approve": "APPROVA",

--- a/lib/app_pt.arb
+++ b/lib/app_pt.arb
@@ -406,6 +406,7 @@
   "payment_info_dialog_hint_expanded": "Insira uma fatura, ID de servidor ou endereço Relâmpago.",
   "payment_info_dialog_barcode": "Ler código de barras",
   "payment_info_dialog_error": "A fatura, o ID ou o endereço é inválido",
+  "payment_info_dialog_error_unsupported_input": "Unsupported input",
   "payment_info_dialog_error_qrcode": "O código QR não foi detectado.",
   "payment_info_dialog_action_cancel": "CANCELAR",
   "payment_info_dialog_action_approve": "APROVAR",

--- a/lib/app_pt.arb
+++ b/lib/app_pt.arb
@@ -1892,7 +1892,7 @@
       }
     }
   },
-  "lnurl_error_unsupported": "LNUrl não suportada",
+  "lnurl_error_unsupported": "LNURL não suportada",
   "make_invoice_request_title": "Este site deseja lhe pagar:",
   "make_invoice_request_action_cancel": "CANCELAR",
   "make_invoice_request_action_approve": "APROVAR",

--- a/lib/app_sk.arb
+++ b/lib/app_sk.arb
@@ -406,6 +406,7 @@
   "payment_info_dialog_hint_expanded": "Zadaj faktúru, ID nody alebo Lightning adresu.",
   "payment_info_dialog_barcode": "Naskenuj čiarový kód",
   "payment_info_dialog_error": "Neplatná faktúra, ID alebo adresa",
+  "payment_info_dialog_error_unsupported_input": "Unsupported input",
   "payment_info_dialog_error_qrcode": "QR kód nebol rozpoznaný.",
   "payment_info_dialog_action_cancel": "ZRUŠIŤ",
   "payment_info_dialog_action_approve": "SCHVÁLIŤ",

--- a/lib/app_sk.arb
+++ b/lib/app_sk.arb
@@ -1892,7 +1892,7 @@
       }
     }
   },
-  "lnurl_error_unsupported": "Nepodporovaná LNUrl",
+  "lnurl_error_unsupported": "Nepodporovaná LNURL",
   "make_invoice_request_title": "Táto stránka ti chce zaplatiť:",
   "make_invoice_request_action_cancel": "ZRUŠIŤ",
   "make_invoice_request_action_approve": "SCHVÁLIŤ",

--- a/lib/app_sv.arb
+++ b/lib/app_sv.arb
@@ -406,6 +406,7 @@
   "payment_info_dialog_hint_expanded": "Ange en Invoice, Nod-ID eller en Lightning-adress.",
   "payment_info_dialog_barcode": "Scanna Barcode",
   "payment_info_dialog_error": "Ogiltig invoice, ID eller Adress",
+  "payment_info_dialog_error_unsupported_input": "Unsupported input",
   "payment_info_dialog_error_qrcode": "QR-kod upptäcktes inte.",
   "payment_info_dialog_action_cancel": "AVBRYT",
   "payment_info_dialog_action_approve": "GODKÄNN",

--- a/lib/app_sv.arb
+++ b/lib/app_sv.arb
@@ -1892,7 +1892,7 @@
       }
     }
   },
-  "lnurl_error_unsupported": "Osupporterad LNUrl",
+  "lnurl_error_unsupported": "Osupporterad LNURL",
   "make_invoice_request_title": "Den här sidan vill betala dig:",
   "make_invoice_request_action_cancel": "AVBRYT",
   "make_invoice_request_action_approve": "GODKÄNN",

--- a/lib/generated/breez_translations.dart
+++ b/lib/generated/breez_translations.dart
@@ -943,6 +943,12 @@ abstract class BreezTranslations {
   /// **'Invalid invoice, ID or Address'**
   String get payment_info_dialog_error;
 
+  /// No description provided for @payment_info_dialog_error_unsupported_input.
+  ///
+  /// In en, this message translates to:
+  /// **'Unsupported input'**
+  String get payment_info_dialog_error_unsupported_input;
+
   /// No description provided for @payment_info_dialog_error_qrcode.
   ///
   /// In en, this message translates to:

--- a/lib/generated/breez_translations.dart
+++ b/lib/generated/breez_translations.dart
@@ -4846,7 +4846,7 @@ abstract class BreezTranslations {
   /// No description provided for @lnurl_error_unsupported.
   ///
   /// In en, this message translates to:
-  /// **'Unsupported LNUrl'**
+  /// **'Unsupported LNURL'**
   String get lnurl_error_unsupported;
 
   /// No description provided for @make_invoice_request_title.

--- a/lib/generated/breez_translations_de.dart
+++ b/lib/generated/breez_translations_de.dart
@@ -472,6 +472,9 @@ class BreezTranslationsDe extends BreezTranslations {
   String get payment_info_dialog_error => 'Ungültige Rechnung, ID oder Adresse';
 
   @override
+  String get payment_info_dialog_error_unsupported_input => 'Unsupported input';
+
+  @override
   String get payment_info_dialog_error_qrcode => 'QR-Code wurde nicht erkannt.';
 
   @override

--- a/lib/generated/breez_translations_el.dart
+++ b/lib/generated/breez_translations_el.dart
@@ -2600,7 +2600,7 @@ class BreezTranslationsEl extends BreezTranslations {
   }
 
   @override
-  String get lnurl_error_unsupported => 'Unsupported LNUrl';
+  String get lnurl_error_unsupported => 'Unsupported LNURL';
 
   @override
   String get make_invoice_request_title => 'This site wants to pay you:';

--- a/lib/generated/breez_translations_el.dart
+++ b/lib/generated/breez_translations_el.dart
@@ -472,6 +472,9 @@ class BreezTranslationsEl extends BreezTranslations {
   String get payment_info_dialog_error => 'Invalid invoice, ID or Address';
 
   @override
+  String get payment_info_dialog_error_unsupported_input => 'Unsupported input';
+
+  @override
   String get payment_info_dialog_error_qrcode => 'QR code wasn\'t detected.';
 
   @override

--- a/lib/generated/breez_translations_en.dart
+++ b/lib/generated/breez_translations_en.dart
@@ -472,6 +472,9 @@ class BreezTranslationsEn extends BreezTranslations {
   String get payment_info_dialog_error => 'Invalid invoice, ID or Address';
 
   @override
+  String get payment_info_dialog_error_unsupported_input => 'Unsupported input';
+
+  @override
   String get payment_info_dialog_error_qrcode => 'QR code wasn\'t detected.';
 
   @override

--- a/lib/generated/breez_translations_en.dart
+++ b/lib/generated/breez_translations_en.dart
@@ -2600,7 +2600,7 @@ class BreezTranslationsEn extends BreezTranslations {
   }
 
   @override
-  String get lnurl_error_unsupported => 'Unsupported LNUrl';
+  String get lnurl_error_unsupported => 'Unsupported LNURL';
 
   @override
   String get make_invoice_request_title => 'This site wants to pay you:';

--- a/lib/generated/breez_translations_es.dart
+++ b/lib/generated/breez_translations_es.dart
@@ -2600,7 +2600,7 @@ class BreezTranslationsEs extends BreezTranslations {
   }
 
   @override
-  String get lnurl_error_unsupported => 'LNUrl no compatible';
+  String get lnurl_error_unsupported => 'LNURL no compatible';
 
   @override
   String get make_invoice_request_title => 'Este sitio quiere pagarte:';

--- a/lib/generated/breez_translations_es.dart
+++ b/lib/generated/breez_translations_es.dart
@@ -472,6 +472,9 @@ class BreezTranslationsEs extends BreezTranslations {
   String get payment_info_dialog_error => 'Factura, ID o dirección incorrecta.';
 
   @override
+  String get payment_info_dialog_error_unsupported_input => 'Unsupported input';
+
+  @override
   String get payment_info_dialog_error_qrcode => 'No se detectó el código QR.';
 
   @override

--- a/lib/generated/breez_translations_fi.dart
+++ b/lib/generated/breez_translations_fi.dart
@@ -472,6 +472,9 @@ class BreezTranslationsFi extends BreezTranslations {
   String get payment_info_dialog_error => 'LN-lasku, solmu- tai Lightning-osoite oli virheellinen.';
 
   @override
+  String get payment_info_dialog_error_unsupported_input => 'Unsupported input';
+
+  @override
   String get payment_info_dialog_error_qrcode => 'QR-koodia ei tunnistettu.';
 
   @override

--- a/lib/generated/breez_translations_fi.dart
+++ b/lib/generated/breez_translations_fi.dart
@@ -2600,7 +2600,7 @@ class BreezTranslationsFi extends BreezTranslations {
   }
 
   @override
-  String get lnurl_error_unsupported => 'LNUrl muoto ei ole tuettu';
+  String get lnurl_error_unsupported => 'LNURL muoto ei ole tuettu';
 
   @override
   String get make_invoice_request_title => 'Sivusto haluaa maksaa sinulle:';

--- a/lib/generated/breez_translations_fr.dart
+++ b/lib/generated/breez_translations_fr.dart
@@ -2600,7 +2600,7 @@ class BreezTranslationsFr extends BreezTranslations {
   }
 
   @override
-  String get lnurl_error_unsupported => 'LNUrl non supporté';
+  String get lnurl_error_unsupported => 'LNURL non supporté';
 
   @override
   String get make_invoice_request_title => 'Ce site veut vous payer :';

--- a/lib/generated/breez_translations_fr.dart
+++ b/lib/generated/breez_translations_fr.dart
@@ -472,6 +472,9 @@ class BreezTranslationsFr extends BreezTranslations {
   String get payment_info_dialog_error => 'Facture, ID ou adresse non valide';
 
   @override
+  String get payment_info_dialog_error_unsupported_input => 'Unsupported input';
+
+  @override
   String get payment_info_dialog_error_qrcode => 'Le code QR n\'a pas été détecté.';
 
   @override

--- a/lib/generated/breez_translations_it.dart
+++ b/lib/generated/breez_translations_it.dart
@@ -472,6 +472,9 @@ class BreezTranslationsIt extends BreezTranslations {
   String get payment_info_dialog_error => 'Invoice, ID or indirizzo non valido';
 
   @override
+  String get payment_info_dialog_error_unsupported_input => 'Unsupported input';
+
+  @override
   String get payment_info_dialog_error_qrcode => 'Nessun QR code rilevato.';
 
   @override

--- a/lib/generated/breez_translations_pt.dart
+++ b/lib/generated/breez_translations_pt.dart
@@ -472,6 +472,9 @@ class BreezTranslationsPt extends BreezTranslations {
   String get payment_info_dialog_error => 'A fatura, o ID ou o endereço é inválido';
 
   @override
+  String get payment_info_dialog_error_unsupported_input => 'Unsupported input';
+
+  @override
   String get payment_info_dialog_error_qrcode => 'O código QR não foi detectado.';
 
   @override

--- a/lib/generated/breez_translations_pt.dart
+++ b/lib/generated/breez_translations_pt.dart
@@ -2600,7 +2600,7 @@ class BreezTranslationsPt extends BreezTranslations {
   }
 
   @override
-  String get lnurl_error_unsupported => 'LNUrl não suportada';
+  String get lnurl_error_unsupported => 'LNURL não suportada';
 
   @override
   String get make_invoice_request_title => 'Este site deseja lhe pagar:';

--- a/lib/generated/breez_translations_sk.dart
+++ b/lib/generated/breez_translations_sk.dart
@@ -472,6 +472,9 @@ class BreezTranslationsSk extends BreezTranslations {
   String get payment_info_dialog_error => 'Neplatná faktúra, ID alebo adresa';
 
   @override
+  String get payment_info_dialog_error_unsupported_input => 'Unsupported input';
+
+  @override
   String get payment_info_dialog_error_qrcode => 'QR kód nebol rozpoznaný.';
 
   @override

--- a/lib/generated/breez_translations_sk.dart
+++ b/lib/generated/breez_translations_sk.dart
@@ -2600,7 +2600,7 @@ class BreezTranslationsSk extends BreezTranslations {
   }
 
   @override
-  String get lnurl_error_unsupported => 'Nepodporovaná LNUrl';
+  String get lnurl_error_unsupported => 'Nepodporovaná LNURL';
 
   @override
   String get make_invoice_request_title => 'Táto stránka ti chce zaplatiť:';

--- a/lib/generated/breez_translations_sv.dart
+++ b/lib/generated/breez_translations_sv.dart
@@ -472,6 +472,9 @@ class BreezTranslationsSv extends BreezTranslations {
   String get payment_info_dialog_error => 'Ogiltig invoice, ID eller Adress';
 
   @override
+  String get payment_info_dialog_error_unsupported_input => 'Unsupported input';
+
+  @override
   String get payment_info_dialog_error_qrcode => 'QR-kod upptäcktes inte.';
 
   @override

--- a/lib/generated/breez_translations_sv.dart
+++ b/lib/generated/breez_translations_sv.dart
@@ -2600,7 +2600,7 @@ class BreezTranslationsSv extends BreezTranslations {
   }
 
   @override
-  String get lnurl_error_unsupported => 'Osupporterad LNUrl';
+  String get lnurl_error_unsupported => 'Osupporterad LNURL';
 
   @override
   String get make_invoice_request_title => 'Den här sidan vill betala dig:';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dev_dependencies:
   build_runner: <2.4.0 # Requires Flutter 3.10
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.1
+  flutter_lints: ^2.0.2
 
 dependency_overrides:
   intl: ^0.18.1


### PR DESCRIPTION
This PR introduces `payment_info_dialog_error_unsupported_input` text with `Unsupported input` message as part of https://github.com/breez/c-breez/issues/591

#### Other changes:
- Standardize LNURL capitalization
  - LNUrl -> LNURL