### PR TITLE
Add iOS strings for Satscard integration

### DIFF
--- a/lib/app_bg.arb
+++ b/lib/app_bg.arb
@@ -320,6 +320,8 @@
   "bottom_action_bar_receive_invoice": "Получаване чрез фактура",
   "bottom_action_bar_receive_btc_address": "Получаване чрез BTC адрес",
   "bottom_action_bar_buy_bitcoin": "Купете Биткойн",
+  "bottom_action_bar_sweep_satscard": "Sweep Satscard",
+  "bottom_action_bar_sweep_satscard_nfc_prompt": "Please hold a Satscard against your device.",
   "bottom_action_bar_warning_balance_title": "Breez изисква да поддържате {balance} в баланса си.",
   "@bottom_action_bar_warning_balance_title": {
     "placeholders": {
@@ -2356,6 +2358,8 @@
   "google_sign_not_available_exception": "Влизането в Google не е налично на това устройство.",
   "satscard_dialog_ok": "OK",
   "satscard_dialog_cancel": "CANCEL",
+  "satscard_ios_success_label": "Satscard was successfully scanned",
+  "satscard_ios_error_label": "Unable to scan the Satscard",
   "satscard_error_invalid_title": "Unknown Error",
   "satscard_error_invalid_body": "Communication with the Satscard failed unexpectedly:\n{error}",
   "satscard_error_nfc_title": "Communication Error",
@@ -2447,10 +2451,21 @@
   "satscard_broadcast_complete_title": "Satscard Swept",
   "satscard_operation_dialog_title": "Scan Satscard",
   "satscard_operation_dialog_cancel_label": "CANCEL",
+  "satscard_operation_dialog_content_ios_label": "Tap the NFC icon to try again...",
   "satscard_operation_dialog_present_satscards_label": "Please hold the Satscard with the following ID against your device:\n{id}",
   "satscard_operation_dialog_success_label": "Operation complete",
   "satscard_operation_dialog_in_progress_label": "Communicating with Satscard",
   "satscard_operation_dialog_waiting_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device",
+  "satscard_operation_dialog_waiting_ios_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device ({percent})",
+  "@satscard_operation_dialog_waiting_ios_label": {
+    "description": "The wait progress as a percentage",
+    "placeholders": {
+      "percent": {
+        "type": "double",
+        "format": "percentPattern"
+      }
+    }
+  },
   "satscard_operation_dialog_incorrect_card_label": "Incorrect card presented, the ID on the rear of the card must be:\n{id}",
   "satscard_operation_dialog_incorrect_code_label": "Incorrect spend code",
   "satscard_operation_dialog_stale_card_label": "The correct card was presented but it's in an unexpected state, it may have been modified outside of the app.",

--- a/lib/app_cs.arb
+++ b/lib/app_cs.arb
@@ -320,6 +320,8 @@
   "bottom_action_bar_receive_invoice": "Příjem prostřednictvím LN faktury",
   "bottom_action_bar_receive_btc_address": "Příjem prostřednictvím adresy BTC",
   "bottom_action_bar_buy_bitcoin": "Nakupte bitcoiny",
+  "bottom_action_bar_sweep_satscard": "Sweep Satscard",
+  "bottom_action_bar_sweep_satscard_nfc_prompt": "Please hold a Satscard against your device.",
   "bottom_action_bar_warning_balance_title": "Breez vyžaduje, abyste ve svém zůstatku udržovali {balance}.",
   "@bottom_action_bar_warning_balance_title": {
     "placeholders": {
@@ -2356,6 +2358,8 @@
   "google_sign_not_available_exception": "Google Sign-In is not available on this device.",
   "satscard_dialog_ok": "OK",
   "satscard_dialog_cancel": "CANCEL",
+  "satscard_ios_success_label": "Satscard was successfully scanned",
+  "satscard_ios_error_label": "Unable to scan the Satscard",
   "satscard_error_invalid_title": "Unknown Error",
   "satscard_error_invalid_body": "Communication with the Satscard failed unexpectedly:\n{error}",
   "satscard_error_nfc_title": "Communication Error",
@@ -2447,10 +2451,21 @@
   "satscard_broadcast_complete_title": "Satscard Swept",
   "satscard_operation_dialog_title": "Scan Satscard",
   "satscard_operation_dialog_cancel_label": "CANCEL",
+  "satscard_operation_dialog_content_ios_label": "Tap the NFC icon to try again...",
   "satscard_operation_dialog_present_satscards_label": "Please hold the Satscard with the following ID against your device:\n{id}",
   "satscard_operation_dialog_success_label": "Operation complete",
   "satscard_operation_dialog_in_progress_label": "Communicating with Satscard",
   "satscard_operation_dialog_waiting_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device",
+  "satscard_operation_dialog_waiting_ios_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device ({percent})",
+  "@satscard_operation_dialog_waiting_ios_label": {
+    "description": "The wait progress as a percentage",
+    "placeholders": {
+      "percent": {
+        "type": "double",
+        "format": "percentPattern"
+      }
+    }
+  },
   "satscard_operation_dialog_incorrect_card_label": "Incorrect card presented, the ID on the rear of the card must be:\n{id}",
   "satscard_operation_dialog_incorrect_code_label": "Incorrect spend code",
   "satscard_operation_dialog_stale_card_label": "The correct card was presented but it's in an unexpected state, it may have been modified outside of the app.",

--- a/lib/app_de.arb
+++ b/lib/app_de.arb
@@ -320,6 +320,8 @@
   "bottom_action_bar_receive_invoice": "Lightning-Rechnung erstellen",
   "bottom_action_bar_receive_btc_address": "Via BTC Adresse empfangen",
   "bottom_action_bar_buy_bitcoin": "Bitcoin kaufen",
+  "bottom_action_bar_sweep_satscard": "Sweep Satscard",
+  "bottom_action_bar_sweep_satscard_nfc_prompt": "Please hold a Satscard against your device.",
   "bottom_action_bar_warning_balance_title": "Breez benötigt {balance} auf deinem Konto.",
   "@bottom_action_bar_warning_balance_title": {
     "placeholders": {
@@ -2356,6 +2358,8 @@
   "google_sign_not_available_exception": "Google Sign-In is not available on this device.",
   "satscard_dialog_ok": "OK",
   "satscard_dialog_cancel": "CANCEL",
+  "satscard_ios_success_label": "Satscard was successfully scanned",
+  "satscard_ios_error_label": "Unable to scan the Satscard",
   "satscard_error_invalid_title": "Unknown Error",
   "satscard_error_invalid_body": "Communication with the Satscard failed unexpectedly:\n{error}",
   "satscard_error_nfc_title": "Communication Error",
@@ -2447,10 +2451,21 @@
   "satscard_broadcast_complete_title": "Satscard Swept",
   "satscard_operation_dialog_title": "Scan Satscard",
   "satscard_operation_dialog_cancel_label": "CANCEL",
+  "satscard_operation_dialog_content_ios_label": "Tap the NFC icon to try again...",
   "satscard_operation_dialog_present_satscards_label": "Please hold the Satscard with the following ID against your device:\n{id}",
   "satscard_operation_dialog_success_label": "Operation complete",
   "satscard_operation_dialog_in_progress_label": "Communicating with Satscard",
   "satscard_operation_dialog_waiting_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device",
+  "satscard_operation_dialog_waiting_ios_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device ({percent})",
+  "@satscard_operation_dialog_waiting_ios_label": {
+    "description": "The wait progress as a percentage",
+    "placeholders": {
+      "percent": {
+        "type": "double",
+        "format": "percentPattern"
+      }
+    }
+  },
   "satscard_operation_dialog_incorrect_card_label": "Incorrect card presented, the ID on the rear of the card must be:\n{id}",
   "satscard_operation_dialog_incorrect_code_label": "Incorrect spend code",
   "satscard_operation_dialog_stale_card_label": "The correct card was presented but it's in an unexpected state, it may have been modified outside of the app.",

--- a/lib/app_el.arb
+++ b/lib/app_el.arb
@@ -320,6 +320,8 @@
   "bottom_action_bar_receive_invoice": "Receive via Invoice",
   "bottom_action_bar_receive_btc_address": "Λήψη μέσω διεύθυνσης BTC",
   "bottom_action_bar_buy_bitcoin": "Αγοράστε Bitcoin",
+  "bottom_action_bar_sweep_satscard": "Sweep Satscard",
+  "bottom_action_bar_sweep_satscard_nfc_prompt": "Please hold a Satscard against your device.",
   "bottom_action_bar_warning_balance_title": "Breez requires you to keep {balance} in your balance.",
   "@bottom_action_bar_warning_balance_title": {
     "placeholders": {
@@ -2356,6 +2358,8 @@
   "google_sign_not_available_exception": "Google Sign-In is not available on this device.",
   "satscard_dialog_ok": "OK",
   "satscard_dialog_cancel": "CANCEL",
+  "satscard_ios_success_label": "Satscard was successfully scanned",
+  "satscard_ios_error_label": "Unable to scan the Satscard",
   "satscard_error_invalid_title": "Unknown Error",
   "satscard_error_invalid_body": "Communication with the Satscard failed unexpectedly:\n{error}",
   "satscard_error_nfc_title": "Communication Error",
@@ -2447,10 +2451,21 @@
   "satscard_broadcast_complete_title": "Satscard Swept",
   "satscard_operation_dialog_title": "Scan Satscard",
   "satscard_operation_dialog_cancel_label": "CANCEL",
+  "satscard_operation_dialog_content_ios_label": "Tap the NFC icon to try again...",
   "satscard_operation_dialog_present_satscards_label": "Please hold the Satscard with the following ID against your device:\n{id}",
   "satscard_operation_dialog_success_label": "Operation complete",
   "satscard_operation_dialog_in_progress_label": "Communicating with Satscard",
   "satscard_operation_dialog_waiting_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device",
+  "satscard_operation_dialog_waiting_ios_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device ({percent})",
+  "@satscard_operation_dialog_waiting_ios_label": {
+    "description": "The wait progress as a percentage",
+    "placeholders": {
+      "percent": {
+        "type": "double",
+        "format": "percentPattern"
+      }
+    }
+  },
   "satscard_operation_dialog_incorrect_card_label": "Incorrect card presented, the ID on the rear of the card must be:\n{id}",
   "satscard_operation_dialog_incorrect_code_label": "Incorrect spend code",
   "satscard_operation_dialog_stale_card_label": "The correct card was presented but it's in an unexpected state, it may have been modified outside of the app.",

--- a/lib/app_en.arb
+++ b/lib/app_en.arb
@@ -320,6 +320,8 @@
   "bottom_action_bar_receive_invoice": "Receive via Invoice",
   "bottom_action_bar_receive_btc_address": "Receive via BTC Address",
   "bottom_action_bar_buy_bitcoin": "Buy Bitcoin",
+  "bottom_action_bar_sweep_satscard": "Sweep Satscard",
+  "bottom_action_bar_sweep_satscard_nfc_prompt": "Please hold a Satscard against your device.",
   "bottom_action_bar_warning_balance_title": "Breez requires you to keep {balance} in your balance.",
   "@bottom_action_bar_warning_balance_title": {
     "placeholders": {
@@ -2356,6 +2358,8 @@
   "google_sign_not_available_exception": "Google Sign-In is not available on this device.",
   "satscard_dialog_ok": "OK",
   "satscard_dialog_cancel": "CANCEL",
+  "satscard_ios_success_label": "Satscard was successfully scanned",
+  "satscard_ios_error_label": "Unable to scan the Satscard",
   "satscard_error_invalid_title": "Unknown Error",
   "satscard_error_invalid_body": "Communication with the Satscard failed unexpectedly:\n{error}",
   "satscard_error_nfc_title": "Communication Error",
@@ -2447,10 +2451,21 @@
   "satscard_broadcast_complete_title": "Satscard Swept",
   "satscard_operation_dialog_title": "Scan Satscard",
   "satscard_operation_dialog_cancel_label": "CANCEL",
+  "satscard_operation_dialog_content_ios_label": "Tap the NFC icon to try again...",
   "satscard_operation_dialog_present_satscards_label": "Please hold the Satscard with the following ID against your device:\n{id}",
   "satscard_operation_dialog_success_label": "Operation complete",
   "satscard_operation_dialog_in_progress_label": "Communicating with Satscard",
   "satscard_operation_dialog_waiting_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device",
+  "satscard_operation_dialog_waiting_ios_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device ({percent})",
+  "@satscard_operation_dialog_waiting_ios_label": {
+    "description": "The wait progress as a percentage",
+    "placeholders": {
+      "percent": {
+        "type": "double",
+        "format": "percentPattern"
+      }
+    }
+  },
   "satscard_operation_dialog_incorrect_card_label": "Incorrect card presented, the ID on the rear of the card must be:\n{id}",
   "satscard_operation_dialog_incorrect_code_label": "Incorrect spend code",
   "satscard_operation_dialog_stale_card_label": "The correct card was presented but it's in an unexpected state, it may have been modified outside of the app.",

--- a/lib/app_es.arb
+++ b/lib/app_es.arb
@@ -320,6 +320,8 @@
   "bottom_action_bar_receive_invoice": "Recibir por Factura",
   "bottom_action_bar_receive_btc_address": "Recibir desde Dirección BTC",
   "bottom_action_bar_buy_bitcoin": "Comprar Bitcoin",
+  "bottom_action_bar_sweep_satscard": "Sweep Satscard",
+  "bottom_action_bar_sweep_satscard_nfc_prompt": "Please hold a Satscard against your device.",
   "bottom_action_bar_warning_balance_title": "Breez requiere que mtenga al menos {balance} de saldo.",
   "@bottom_action_bar_warning_balance_title": {
     "placeholders": {
@@ -2356,6 +2358,8 @@
   "google_sign_not_available_exception": "Autenticación de Google no disponible en este dispositivo",
   "satscard_dialog_ok": "OK",
   "satscard_dialog_cancel": "CANCEL",
+  "satscard_ios_success_label": "Satscard was successfully scanned",
+  "satscard_ios_error_label": "Unable to scan the Satscard",
   "satscard_error_invalid_title": "Unknown Error",
   "satscard_error_invalid_body": "Communication with the Satscard failed unexpectedly:\n{error}",
   "satscard_error_nfc_title": "Communication Error",
@@ -2447,10 +2451,21 @@
   "satscard_broadcast_complete_title": "Satscard Swept",
   "satscard_operation_dialog_title": "Scan Satscard",
   "satscard_operation_dialog_cancel_label": "CANCEL",
+  "satscard_operation_dialog_content_ios_label": "Tap the NFC icon to try again...",
   "satscard_operation_dialog_present_satscards_label": "Please hold the Satscard with the following ID against your device:\n{id}",
   "satscard_operation_dialog_success_label": "Operation complete",
   "satscard_operation_dialog_in_progress_label": "Communicating with Satscard",
   "satscard_operation_dialog_waiting_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device",
+  "satscard_operation_dialog_waiting_ios_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device ({percent})",
+  "@satscard_operation_dialog_waiting_ios_label": {
+    "description": "The wait progress as a percentage",
+    "placeholders": {
+      "percent": {
+        "type": "double",
+        "format": "percentPattern"
+      }
+    }
+  },
   "satscard_operation_dialog_incorrect_card_label": "Incorrect card presented, the ID on the rear of the card must be:\n{id}",
   "satscard_operation_dialog_incorrect_code_label": "Incorrect spend code",
   "satscard_operation_dialog_stale_card_label": "The correct card was presented but it's in an unexpected state, it may have been modified outside of the app.",

--- a/lib/app_fi.arb
+++ b/lib/app_fi.arb
@@ -320,6 +320,8 @@
   "bottom_action_bar_receive_invoice": "Lightning-maksu",
   "bottom_action_bar_receive_btc_address": "Bitcoin-maksu",
   "bottom_action_bar_buy_bitcoin": "Osta bitcoineja",
+  "bottom_action_bar_sweep_satscard": "Sweep Satscard",
+  "bottom_action_bar_sweep_satscard_nfc_prompt": "Please hold a Satscard against your device.",
   "bottom_action_bar_warning_balance_title": "Breez vaatii, että saldosi on vähintään {balance}.",
   "@bottom_action_bar_warning_balance_title": {
     "placeholders": {
@@ -2356,6 +2358,8 @@
   "google_sign_not_available_exception": "Google Sign-In is not available on this device.",
   "satscard_dialog_ok": "OK",
   "satscard_dialog_cancel": "CANCEL",
+  "satscard_ios_success_label": "Satscard was successfully scanned",
+  "satscard_ios_error_label": "Unable to scan the Satscard",
   "satscard_error_invalid_title": "Unknown Error",
   "satscard_error_invalid_body": "Communication with the Satscard failed unexpectedly:\n{error}",
   "satscard_error_nfc_title": "Communication Error",
@@ -2447,10 +2451,21 @@
   "satscard_broadcast_complete_title": "Satscard Swept",
   "satscard_operation_dialog_title": "Scan Satscard",
   "satscard_operation_dialog_cancel_label": "CANCEL",
+  "satscard_operation_dialog_content_ios_label": "Tap the NFC icon to try again...",
   "satscard_operation_dialog_present_satscards_label": "Please hold the Satscard with the following ID against your device:\n{id}",
   "satscard_operation_dialog_success_label": "Operation complete",
   "satscard_operation_dialog_in_progress_label": "Communicating with Satscard",
   "satscard_operation_dialog_waiting_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device",
+  "satscard_operation_dialog_waiting_ios_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device ({percent})",
+  "@satscard_operation_dialog_waiting_ios_label": {
+    "description": "The wait progress as a percentage",
+    "placeholders": {
+      "percent": {
+        "type": "double",
+        "format": "percentPattern"
+      }
+    }
+  },
   "satscard_operation_dialog_incorrect_card_label": "Incorrect card presented, the ID on the rear of the card must be:\n{id}",
   "satscard_operation_dialog_incorrect_code_label": "Incorrect spend code",
   "satscard_operation_dialog_stale_card_label": "The correct card was presented but it's in an unexpected state, it may have been modified outside of the app.",

--- a/lib/app_fr.arb
+++ b/lib/app_fr.arb
@@ -320,6 +320,8 @@
   "bottom_action_bar_receive_invoice": "Recevoir par facture",
   "bottom_action_bar_receive_btc_address": "Recevoir via une adresse BTC",
   "bottom_action_bar_buy_bitcoin": "Acheter du bitcoin",
+  "bottom_action_bar_sweep_satscard": "Sweep Satscard",
+  "bottom_action_bar_sweep_satscard_nfc_prompt": "Please hold a Satscard against your device.",
   "bottom_action_bar_warning_balance_title": "Breez exige que vous gardiez {balance} dans votre solde.",
   "@bottom_action_bar_warning_balance_title": {
     "placeholders": {
@@ -2356,6 +2358,8 @@
   "google_sign_not_available_exception": "Google Sign-In is not available on this device.",
   "satscard_dialog_ok": "OK",
   "satscard_dialog_cancel": "CANCEL",
+  "satscard_ios_success_label": "Satscard was successfully scanned",
+  "satscard_ios_error_label": "Unable to scan the Satscard",
   "satscard_error_invalid_title": "Unknown Error",
   "satscard_error_invalid_body": "Communication with the Satscard failed unexpectedly:\n{error}",
   "satscard_error_nfc_title": "Communication Error",
@@ -2447,10 +2451,21 @@
   "satscard_broadcast_complete_title": "Satscard Swept",
   "satscard_operation_dialog_title": "Scan Satscard",
   "satscard_operation_dialog_cancel_label": "CANCEL",
+  "satscard_operation_dialog_content_ios_label": "Tap the NFC icon to try again...",
   "satscard_operation_dialog_present_satscards_label": "Please hold the Satscard with the following ID against your device:\n{id}",
   "satscard_operation_dialog_success_label": "Operation complete",
   "satscard_operation_dialog_in_progress_label": "Communicating with Satscard",
   "satscard_operation_dialog_waiting_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device",
+  "satscard_operation_dialog_waiting_ios_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device ({percent})",
+  "@satscard_operation_dialog_waiting_ios_label": {
+    "description": "The wait progress as a percentage",
+    "placeholders": {
+      "percent": {
+        "type": "double",
+        "format": "percentPattern"
+      }
+    }
+  },
   "satscard_operation_dialog_incorrect_card_label": "Incorrect card presented, the ID on the rear of the card must be:\n{id}",
   "satscard_operation_dialog_incorrect_code_label": "Incorrect spend code",
   "satscard_operation_dialog_stale_card_label": "The correct card was presented but it's in an unexpected state, it may have been modified outside of the app.",

--- a/lib/app_it.arb
+++ b/lib/app_it.arb
@@ -320,6 +320,8 @@
   "bottom_action_bar_receive_invoice": "Ricevi tramite Invoice",
   "bottom_action_bar_receive_btc_address": "Ricevi tramite indirizzo BTC",
   "bottom_action_bar_buy_bitcoin": "Compra bitcoin",
+  "bottom_action_bar_sweep_satscard": "Sweep Satscard",
+  "bottom_action_bar_sweep_satscard_nfc_prompt": "Please hold a Satscard against your device.",
   "bottom_action_bar_warning_balance_title": "Breez ti richiede di mantenere {balance} nel tuo saldo.",
   "@bottom_action_bar_warning_balance_title": {
     "placeholders": {
@@ -2356,6 +2358,8 @@
   "google_sign_not_available_exception": "Google Sign-In is not available on this device.",
   "satscard_dialog_ok": "OK",
   "satscard_dialog_cancel": "CANCEL",
+  "satscard_ios_success_label": "Satscard was successfully scanned",
+  "satscard_ios_error_label": "Unable to scan the Satscard",
   "satscard_error_invalid_title": "Unknown Error",
   "satscard_error_invalid_body": "Communication with the Satscard failed unexpectedly:\n{error}",
   "satscard_error_nfc_title": "Communication Error",
@@ -2447,10 +2451,21 @@
   "satscard_broadcast_complete_title": "Satscard Swept",
   "satscard_operation_dialog_title": "Scan Satscard",
   "satscard_operation_dialog_cancel_label": "CANCEL",
+  "satscard_operation_dialog_content_ios_label": "Tap the NFC icon to try again...",
   "satscard_operation_dialog_present_satscards_label": "Please hold the Satscard with the following ID against your device:\n{id}",
   "satscard_operation_dialog_success_label": "Operation complete",
   "satscard_operation_dialog_in_progress_label": "Communicating with Satscard",
   "satscard_operation_dialog_waiting_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device",
+  "satscard_operation_dialog_waiting_ios_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device ({percent})",
+  "@satscard_operation_dialog_waiting_ios_label": {
+    "description": "The wait progress as a percentage",
+    "placeholders": {
+      "percent": {
+        "type": "double",
+        "format": "percentPattern"
+      }
+    }
+  },
   "satscard_operation_dialog_incorrect_card_label": "Incorrect card presented, the ID on the rear of the card must be:\n{id}",
   "satscard_operation_dialog_incorrect_code_label": "Incorrect spend code",
   "satscard_operation_dialog_stale_card_label": "The correct card was presented but it's in an unexpected state, it may have been modified outside of the app.",

--- a/lib/app_pt.arb
+++ b/lib/app_pt.arb
@@ -320,6 +320,8 @@
   "bottom_action_bar_receive_invoice": "Receber via Fatura",
   "bottom_action_bar_receive_btc_address": "Receber via Endereço BTC",
   "bottom_action_bar_buy_bitcoin": "Comprar Bitcoin",
+  "bottom_action_bar_sweep_satscard": "Sweep Satscard",
+  "bottom_action_bar_sweep_satscard_nfc_prompt": "Please hold a Satscard against your device.",
   "bottom_action_bar_warning_balance_title": "A Breez requer que você mantenha ao menos {balance} no saldo.",
   "@bottom_action_bar_warning_balance_title": {
     "placeholders": {
@@ -2356,6 +2358,8 @@
   "google_sign_not_available_exception": "A autenticação do Google não está disponível neste dispositivo.",
   "satscard_dialog_ok": "OK",
   "satscard_dialog_cancel": "CANCEL",
+  "satscard_ios_success_label": "Satscard was successfully scanned",
+  "satscard_ios_error_label": "Unable to scan the Satscard",
   "satscard_error_invalid_title": "Unknown Error",
   "satscard_error_invalid_body": "Communication with the Satscard failed unexpectedly:\n{error}",
   "satscard_error_nfc_title": "Communication Error",
@@ -2447,10 +2451,21 @@
   "satscard_broadcast_complete_title": "Satscard Swept",
   "satscard_operation_dialog_title": "Scan Satscard",
   "satscard_operation_dialog_cancel_label": "CANCEL",
+  "satscard_operation_dialog_content_ios_label": "Tap the NFC icon to try again...",
   "satscard_operation_dialog_present_satscards_label": "Please hold the Satscard with the following ID against your device:\n{id}",
   "satscard_operation_dialog_success_label": "Operation complete",
   "satscard_operation_dialog_in_progress_label": "Communicating with Satscard",
   "satscard_operation_dialog_waiting_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device",
+  "satscard_operation_dialog_waiting_ios_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device ({percent})",
+  "@satscard_operation_dialog_waiting_ios_label": {
+    "description": "The wait progress as a percentage",
+    "placeholders": {
+      "percent": {
+        "type": "double",
+        "format": "percentPattern"
+      }
+    }
+  },
   "satscard_operation_dialog_incorrect_card_label": "Incorrect card presented, the ID on the rear of the card must be:\n{id}",
   "satscard_operation_dialog_incorrect_code_label": "Incorrect spend code",
   "satscard_operation_dialog_stale_card_label": "The correct card was presented but it's in an unexpected state, it may have been modified outside of the app.",

--- a/lib/app_sk.arb
+++ b/lib/app_sk.arb
@@ -320,6 +320,8 @@
   "bottom_action_bar_receive_invoice": "Prijať cez Lightning faktúru",
   "bottom_action_bar_receive_btc_address": "Prijať cez BTC adresu",
   "bottom_action_bar_buy_bitcoin": "Kúpiť Bitcoin",
+  "bottom_action_bar_sweep_satscard": "Sweep Satscard",
+  "bottom_action_bar_sweep_satscard_nfc_prompt": "Please hold a Satscard against your device.",
   "bottom_action_bar_warning_balance_title": "Breez vyžaduje, aby si vo svojom zostatku mal minimálne {balance}.",
   "@bottom_action_bar_warning_balance_title": {
     "placeholders": {
@@ -2356,6 +2358,8 @@
   "google_sign_not_available_exception": "Google Sign-In is not available on this device.",
   "satscard_dialog_ok": "OK",
   "satscard_dialog_cancel": "CANCEL",
+  "satscard_ios_success_label": "Satscard was successfully scanned",
+  "satscard_ios_error_label": "Unable to scan the Satscard",
   "satscard_error_invalid_title": "Unknown Error",
   "satscard_error_invalid_body": "Communication with the Satscard failed unexpectedly:\n{error}",
   "satscard_error_nfc_title": "Communication Error",
@@ -2447,10 +2451,21 @@
   "satscard_broadcast_complete_title": "Satscard Swept",
   "satscard_operation_dialog_title": "Scan Satscard",
   "satscard_operation_dialog_cancel_label": "CANCEL",
+  "satscard_operation_dialog_content_ios_label": "Tap the NFC icon to try again...",
   "satscard_operation_dialog_present_satscards_label": "Please hold the Satscard with the following ID against your device:\n{id}",
   "satscard_operation_dialog_success_label": "Operation complete",
   "satscard_operation_dialog_in_progress_label": "Communicating with Satscard",
   "satscard_operation_dialog_waiting_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device",
+  "satscard_operation_dialog_waiting_ios_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device ({percent})",
+  "@satscard_operation_dialog_waiting_ios_label": {
+    "description": "The wait progress as a percentage",
+    "placeholders": {
+      "percent": {
+        "type": "double",
+        "format": "percentPattern"
+      }
+    }
+  },
   "satscard_operation_dialog_incorrect_card_label": "Incorrect card presented, the ID on the rear of the card must be:\n{id}",
   "satscard_operation_dialog_incorrect_code_label": "Incorrect spend code",
   "satscard_operation_dialog_stale_card_label": "The correct card was presented but it's in an unexpected state, it may have been modified outside of the app.",

--- a/lib/app_sv.arb
+++ b/lib/app_sv.arb
@@ -320,6 +320,8 @@
   "bottom_action_bar_receive_invoice": "Ta emot via Invoice",
   "bottom_action_bar_receive_btc_address": "Ta emot via BTC Adress",
   "bottom_action_bar_buy_bitcoin": "Köp Bitcoin",
+  "bottom_action_bar_sweep_satscard": "Sweep Satscard",
+  "bottom_action_bar_sweep_satscard_nfc_prompt": "Please hold a Satscard against your device.",
   "bottom_action_bar_warning_balance_title": "Breez kräver att du har {balance} i ditt saldo.",
   "@bottom_action_bar_warning_balance_title": {
     "placeholders": {
@@ -2356,6 +2358,8 @@
   "google_sign_not_available_exception": "Google Sign-In is not available on this device.",
   "satscard_dialog_ok": "OK",
   "satscard_dialog_cancel": "CANCEL",
+  "satscard_ios_success_label": "Satscard was successfully scanned",
+  "satscard_ios_error_label": "Unable to scan the Satscard",
   "satscard_error_invalid_title": "Unknown Error",
   "satscard_error_invalid_body": "Communication with the Satscard failed unexpectedly:\n{error}",
   "satscard_error_nfc_title": "Communication Error",
@@ -2447,10 +2451,21 @@
   "satscard_broadcast_complete_title": "Satscard Swept",
   "satscard_operation_dialog_title": "Scan Satscard",
   "satscard_operation_dialog_cancel_label": "CANCEL",
+  "satscard_operation_dialog_content_ios_label": "Tap the NFC icon to try again...",
   "satscard_operation_dialog_present_satscards_label": "Please hold the Satscard with the following ID against your device:\n{id}",
   "satscard_operation_dialog_success_label": "Operation complete",
   "satscard_operation_dialog_in_progress_label": "Communicating with Satscard",
   "satscard_operation_dialog_waiting_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device",
+  "satscard_operation_dialog_waiting_ios_label": "An incorrect spend code was previously entered. Please keep the Satscard held against your device ({percent})",
+  "@satscard_operation_dialog_waiting_ios_label": {
+    "description": "The wait progress as a percentage",
+    "placeholders": {
+      "percent": {
+        "type": "double",
+        "format": "percentPattern"
+      }
+    }
+  },
   "satscard_operation_dialog_incorrect_card_label": "Incorrect card presented, the ID on the rear of the card must be:\n{id}",
   "satscard_operation_dialog_incorrect_code_label": "Incorrect spend code",
   "satscard_operation_dialog_stale_card_label": "The correct card was presented but it's in an unexpected state, it may have been modified outside of the app.",

--- a/lib/generated/breez_translations.dart
+++ b/lib/generated/breez_translations.dart
@@ -719,6 +719,18 @@ abstract class BreezTranslations {
   /// **'Buy Bitcoin'**
   String get bottom_action_bar_buy_bitcoin;
 
+  /// No description provided for @bottom_action_bar_sweep_satscard.
+  ///
+  /// In en, this message translates to:
+  /// **'Sweep Satscard'**
+  String get bottom_action_bar_sweep_satscard;
+
+  /// No description provided for @bottom_action_bar_sweep_satscard_nfc_prompt.
+  ///
+  /// In en, this message translates to:
+  /// **'Please hold a Satscard against your device.'**
+  String get bottom_action_bar_sweep_satscard_nfc_prompt;
+
   /// No description provided for @bottom_action_bar_warning_balance_title.
   ///
   /// In en, this message translates to:
@@ -6167,6 +6179,18 @@ abstract class BreezTranslations {
   /// **'CANCEL'**
   String get satscard_dialog_cancel;
 
+  /// No description provided for @satscard_ios_success_label.
+  ///
+  /// In en, this message translates to:
+  /// **'Satscard was successfully scanned'**
+  String get satscard_ios_success_label;
+
+  /// No description provided for @satscard_ios_error_label.
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to scan the Satscard'**
+  String get satscard_ios_error_label;
+
   /// No description provided for @satscard_error_invalid_title.
   ///
   /// In en, this message translates to:
@@ -6545,6 +6569,12 @@ abstract class BreezTranslations {
   /// **'CANCEL'**
   String get satscard_operation_dialog_cancel_label;
 
+  /// No description provided for @satscard_operation_dialog_content_ios_label.
+  ///
+  /// In en, this message translates to:
+  /// **'Tap the NFC icon to try again...'**
+  String get satscard_operation_dialog_content_ios_label;
+
   /// No description provided for @satscard_operation_dialog_present_satscards_label.
   ///
   /// In en, this message translates to:
@@ -6568,6 +6598,12 @@ abstract class BreezTranslations {
   /// In en, this message translates to:
   /// **'An incorrect spend code was previously entered. Please keep the Satscard held against your device'**
   String get satscard_operation_dialog_waiting_label;
+
+  /// The wait progress as a percentage
+  ///
+  /// In en, this message translates to:
+  /// **'An incorrect spend code was previously entered. Please keep the Satscard held against your device ({percent})'**
+  String satscard_operation_dialog_waiting_ios_label(double percent);
 
   /// No description provided for @satscard_operation_dialog_incorrect_card_label.
   ///

--- a/lib/generated/breez_translations_bg.dart
+++ b/lib/generated/breez_translations_bg.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart' as intl;
+
 import 'breez_translations.dart';
 
 /// The translations for Bulgarian (`bg`).
@@ -344,6 +346,12 @@ class BreezTranslationsBg extends BreezTranslations {
 
   @override
   String get bottom_action_bar_buy_bitcoin => 'Купете Биткойн';
+
+  @override
+  String get bottom_action_bar_sweep_satscard => 'Sweep Satscard';
+
+  @override
+  String get bottom_action_bar_sweep_satscard_nfc_prompt => 'Please hold a Satscard against your device.';
 
   @override
   String bottom_action_bar_warning_balance_title(String balance) {
@@ -3312,6 +3320,12 @@ class BreezTranslationsBg extends BreezTranslations {
   String get satscard_dialog_cancel => 'CANCEL';
 
   @override
+  String get satscard_ios_success_label => 'Satscard was successfully scanned';
+
+  @override
+  String get satscard_ios_error_label => 'Unable to scan the Satscard';
+
+  @override
   String get satscard_error_invalid_title => 'Unknown Error';
 
   @override
@@ -3529,6 +3543,9 @@ class BreezTranslationsBg extends BreezTranslations {
   String get satscard_operation_dialog_cancel_label => 'CANCEL';
 
   @override
+  String get satscard_operation_dialog_content_ios_label => 'Tap the NFC icon to try again...';
+
+  @override
   String satscard_operation_dialog_present_satscards_label(Object id) {
     return 'Please hold the Satscard with the following ID against your device:\n$id';
   }
@@ -3541,6 +3558,14 @@ class BreezTranslationsBg extends BreezTranslations {
 
   @override
   String get satscard_operation_dialog_waiting_label => 'An incorrect spend code was previously entered. Please keep the Satscard held against your device';
+
+  @override
+  String satscard_operation_dialog_waiting_ios_label(double percent) {
+    final intl.NumberFormat percentNumberFormat = intl.NumberFormat.percentPattern(localeName);
+    final String percentString = percentNumberFormat.format(percent);
+
+    return 'An incorrect spend code was previously entered. Please keep the Satscard held against your device ($percentString)';
+  }
 
   @override
   String satscard_operation_dialog_incorrect_card_label(Object id) {

--- a/lib/generated/breez_translations_cs.dart
+++ b/lib/generated/breez_translations_cs.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart' as intl;
+
 import 'breez_translations.dart';
 
 /// The translations for Czech (`cs`).
@@ -344,6 +346,12 @@ class BreezTranslationsCs extends BreezTranslations {
 
   @override
   String get bottom_action_bar_buy_bitcoin => 'Nakupte bitcoiny';
+
+  @override
+  String get bottom_action_bar_sweep_satscard => 'Sweep Satscard';
+
+  @override
+  String get bottom_action_bar_sweep_satscard_nfc_prompt => 'Please hold a Satscard against your device.';
 
   @override
   String bottom_action_bar_warning_balance_title(String balance) {
@@ -3312,6 +3320,12 @@ class BreezTranslationsCs extends BreezTranslations {
   String get satscard_dialog_cancel => 'CANCEL';
 
   @override
+  String get satscard_ios_success_label => 'Satscard was successfully scanned';
+
+  @override
+  String get satscard_ios_error_label => 'Unable to scan the Satscard';
+
+  @override
   String get satscard_error_invalid_title => 'Unknown Error';
 
   @override
@@ -3529,6 +3543,9 @@ class BreezTranslationsCs extends BreezTranslations {
   String get satscard_operation_dialog_cancel_label => 'CANCEL';
 
   @override
+  String get satscard_operation_dialog_content_ios_label => 'Tap the NFC icon to try again...';
+
+  @override
   String satscard_operation_dialog_present_satscards_label(Object id) {
     return 'Please hold the Satscard with the following ID against your device:\n$id';
   }
@@ -3541,6 +3558,14 @@ class BreezTranslationsCs extends BreezTranslations {
 
   @override
   String get satscard_operation_dialog_waiting_label => 'An incorrect spend code was previously entered. Please keep the Satscard held against your device';
+
+  @override
+  String satscard_operation_dialog_waiting_ios_label(double percent) {
+    final intl.NumberFormat percentNumberFormat = intl.NumberFormat.percentPattern(localeName);
+    final String percentString = percentNumberFormat.format(percent);
+
+    return 'An incorrect spend code was previously entered. Please keep the Satscard held against your device ($percentString)';
+  }
 
   @override
   String satscard_operation_dialog_incorrect_card_label(Object id) {

--- a/lib/generated/breez_translations_de.dart
+++ b/lib/generated/breez_translations_de.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart' as intl;
+
 import 'breez_translations.dart';
 
 /// The translations for German (`de`).
@@ -344,6 +346,12 @@ class BreezTranslationsDe extends BreezTranslations {
 
   @override
   String get bottom_action_bar_buy_bitcoin => 'Bitcoin kaufen';
+
+  @override
+  String get bottom_action_bar_sweep_satscard => 'Sweep Satscard';
+
+  @override
+  String get bottom_action_bar_sweep_satscard_nfc_prompt => 'Please hold a Satscard against your device.';
 
   @override
   String bottom_action_bar_warning_balance_title(String balance) {
@@ -3312,6 +3320,12 @@ class BreezTranslationsDe extends BreezTranslations {
   String get satscard_dialog_cancel => 'CANCEL';
 
   @override
+  String get satscard_ios_success_label => 'Satscard was successfully scanned';
+
+  @override
+  String get satscard_ios_error_label => 'Unable to scan the Satscard';
+
+  @override
   String get satscard_error_invalid_title => 'Unknown Error';
 
   @override
@@ -3529,6 +3543,9 @@ class BreezTranslationsDe extends BreezTranslations {
   String get satscard_operation_dialog_cancel_label => 'CANCEL';
 
   @override
+  String get satscard_operation_dialog_content_ios_label => 'Tap the NFC icon to try again...';
+
+  @override
   String satscard_operation_dialog_present_satscards_label(Object id) {
     return 'Please hold the Satscard with the following ID against your device:\n$id';
   }
@@ -3541,6 +3558,14 @@ class BreezTranslationsDe extends BreezTranslations {
 
   @override
   String get satscard_operation_dialog_waiting_label => 'An incorrect spend code was previously entered. Please keep the Satscard held against your device';
+
+  @override
+  String satscard_operation_dialog_waiting_ios_label(double percent) {
+    final intl.NumberFormat percentNumberFormat = intl.NumberFormat.percentPattern(localeName);
+    final String percentString = percentNumberFormat.format(percent);
+
+    return 'An incorrect spend code was previously entered. Please keep the Satscard held against your device ($percentString)';
+  }
 
   @override
   String satscard_operation_dialog_incorrect_card_label(Object id) {

--- a/lib/generated/breez_translations_el.dart
+++ b/lib/generated/breez_translations_el.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart' as intl;
+
 import 'breez_translations.dart';
 
 /// The translations for Modern Greek (`el`).
@@ -344,6 +346,12 @@ class BreezTranslationsEl extends BreezTranslations {
 
   @override
   String get bottom_action_bar_buy_bitcoin => 'Αγοράστε Bitcoin';
+
+  @override
+  String get bottom_action_bar_sweep_satscard => 'Sweep Satscard';
+
+  @override
+  String get bottom_action_bar_sweep_satscard_nfc_prompt => 'Please hold a Satscard against your device.';
 
   @override
   String bottom_action_bar_warning_balance_title(String balance) {
@@ -3312,6 +3320,12 @@ class BreezTranslationsEl extends BreezTranslations {
   String get satscard_dialog_cancel => 'CANCEL';
 
   @override
+  String get satscard_ios_success_label => 'Satscard was successfully scanned';
+
+  @override
+  String get satscard_ios_error_label => 'Unable to scan the Satscard';
+
+  @override
   String get satscard_error_invalid_title => 'Unknown Error';
 
   @override
@@ -3529,6 +3543,9 @@ class BreezTranslationsEl extends BreezTranslations {
   String get satscard_operation_dialog_cancel_label => 'CANCEL';
 
   @override
+  String get satscard_operation_dialog_content_ios_label => 'Tap the NFC icon to try again...';
+
+  @override
   String satscard_operation_dialog_present_satscards_label(Object id) {
     return 'Please hold the Satscard with the following ID against your device:\n$id';
   }
@@ -3541,6 +3558,14 @@ class BreezTranslationsEl extends BreezTranslations {
 
   @override
   String get satscard_operation_dialog_waiting_label => 'An incorrect spend code was previously entered. Please keep the Satscard held against your device';
+
+  @override
+  String satscard_operation_dialog_waiting_ios_label(double percent) {
+    final intl.NumberFormat percentNumberFormat = intl.NumberFormat.percentPattern(localeName);
+    final String percentString = percentNumberFormat.format(percent);
+
+    return 'An incorrect spend code was previously entered. Please keep the Satscard held against your device ($percentString)';
+  }
 
   @override
   String satscard_operation_dialog_incorrect_card_label(Object id) {

--- a/lib/generated/breez_translations_en.dart
+++ b/lib/generated/breez_translations_en.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart' as intl;
+
 import 'breez_translations.dart';
 
 /// The translations for English (`en`).
@@ -344,6 +346,12 @@ class BreezTranslationsEn extends BreezTranslations {
 
   @override
   String get bottom_action_bar_buy_bitcoin => 'Buy Bitcoin';
+
+  @override
+  String get bottom_action_bar_sweep_satscard => 'Sweep Satscard';
+
+  @override
+  String get bottom_action_bar_sweep_satscard_nfc_prompt => 'Please hold a Satscard against your device.';
 
   @override
   String bottom_action_bar_warning_balance_title(String balance) {
@@ -3312,6 +3320,12 @@ class BreezTranslationsEn extends BreezTranslations {
   String get satscard_dialog_cancel => 'CANCEL';
 
   @override
+  String get satscard_ios_success_label => 'Satscard was successfully scanned';
+
+  @override
+  String get satscard_ios_error_label => 'Unable to scan the Satscard';
+
+  @override
   String get satscard_error_invalid_title => 'Unknown Error';
 
   @override
@@ -3529,6 +3543,9 @@ class BreezTranslationsEn extends BreezTranslations {
   String get satscard_operation_dialog_cancel_label => 'CANCEL';
 
   @override
+  String get satscard_operation_dialog_content_ios_label => 'Tap the NFC icon to try again...';
+
+  @override
   String satscard_operation_dialog_present_satscards_label(Object id) {
     return 'Please hold the Satscard with the following ID against your device:\n$id';
   }
@@ -3541,6 +3558,14 @@ class BreezTranslationsEn extends BreezTranslations {
 
   @override
   String get satscard_operation_dialog_waiting_label => 'An incorrect spend code was previously entered. Please keep the Satscard held against your device';
+
+  @override
+  String satscard_operation_dialog_waiting_ios_label(double percent) {
+    final intl.NumberFormat percentNumberFormat = intl.NumberFormat.percentPattern(localeName);
+    final String percentString = percentNumberFormat.format(percent);
+
+    return 'An incorrect spend code was previously entered. Please keep the Satscard held against your device ($percentString)';
+  }
 
   @override
   String satscard_operation_dialog_incorrect_card_label(Object id) {

--- a/lib/generated/breez_translations_es.dart
+++ b/lib/generated/breez_translations_es.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart' as intl;
+
 import 'breez_translations.dart';
 
 /// The translations for Spanish Castilian (`es`).
@@ -344,6 +346,12 @@ class BreezTranslationsEs extends BreezTranslations {
 
   @override
   String get bottom_action_bar_buy_bitcoin => 'Comprar Bitcoin';
+
+  @override
+  String get bottom_action_bar_sweep_satscard => 'Sweep Satscard';
+
+  @override
+  String get bottom_action_bar_sweep_satscard_nfc_prompt => 'Please hold a Satscard against your device.';
 
   @override
   String bottom_action_bar_warning_balance_title(String balance) {
@@ -3312,6 +3320,12 @@ class BreezTranslationsEs extends BreezTranslations {
   String get satscard_dialog_cancel => 'CANCEL';
 
   @override
+  String get satscard_ios_success_label => 'Satscard was successfully scanned';
+
+  @override
+  String get satscard_ios_error_label => 'Unable to scan the Satscard';
+
+  @override
   String get satscard_error_invalid_title => 'Unknown Error';
 
   @override
@@ -3529,6 +3543,9 @@ class BreezTranslationsEs extends BreezTranslations {
   String get satscard_operation_dialog_cancel_label => 'CANCEL';
 
   @override
+  String get satscard_operation_dialog_content_ios_label => 'Tap the NFC icon to try again...';
+
+  @override
   String satscard_operation_dialog_present_satscards_label(Object id) {
     return 'Please hold the Satscard with the following ID against your device:\n$id';
   }
@@ -3541,6 +3558,14 @@ class BreezTranslationsEs extends BreezTranslations {
 
   @override
   String get satscard_operation_dialog_waiting_label => 'An incorrect spend code was previously entered. Please keep the Satscard held against your device';
+
+  @override
+  String satscard_operation_dialog_waiting_ios_label(double percent) {
+    final intl.NumberFormat percentNumberFormat = intl.NumberFormat.percentPattern(localeName);
+    final String percentString = percentNumberFormat.format(percent);
+
+    return 'An incorrect spend code was previously entered. Please keep the Satscard held against your device ($percentString)';
+  }
 
   @override
   String satscard_operation_dialog_incorrect_card_label(Object id) {

--- a/lib/generated/breez_translations_fi.dart
+++ b/lib/generated/breez_translations_fi.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart' as intl;
+
 import 'breez_translations.dart';
 
 /// The translations for Finnish (`fi`).
@@ -344,6 +346,12 @@ class BreezTranslationsFi extends BreezTranslations {
 
   @override
   String get bottom_action_bar_buy_bitcoin => 'Osta bitcoineja';
+
+  @override
+  String get bottom_action_bar_sweep_satscard => 'Sweep Satscard';
+
+  @override
+  String get bottom_action_bar_sweep_satscard_nfc_prompt => 'Please hold a Satscard against your device.';
 
   @override
   String bottom_action_bar_warning_balance_title(String balance) {
@@ -3312,6 +3320,12 @@ class BreezTranslationsFi extends BreezTranslations {
   String get satscard_dialog_cancel => 'CANCEL';
 
   @override
+  String get satscard_ios_success_label => 'Satscard was successfully scanned';
+
+  @override
+  String get satscard_ios_error_label => 'Unable to scan the Satscard';
+
+  @override
   String get satscard_error_invalid_title => 'Unknown Error';
 
   @override
@@ -3529,6 +3543,9 @@ class BreezTranslationsFi extends BreezTranslations {
   String get satscard_operation_dialog_cancel_label => 'CANCEL';
 
   @override
+  String get satscard_operation_dialog_content_ios_label => 'Tap the NFC icon to try again...';
+
+  @override
   String satscard_operation_dialog_present_satscards_label(Object id) {
     return 'Please hold the Satscard with the following ID against your device:\n$id';
   }
@@ -3541,6 +3558,14 @@ class BreezTranslationsFi extends BreezTranslations {
 
   @override
   String get satscard_operation_dialog_waiting_label => 'An incorrect spend code was previously entered. Please keep the Satscard held against your device';
+
+  @override
+  String satscard_operation_dialog_waiting_ios_label(double percent) {
+    final intl.NumberFormat percentNumberFormat = intl.NumberFormat.percentPattern(localeName);
+    final String percentString = percentNumberFormat.format(percent);
+
+    return 'An incorrect spend code was previously entered. Please keep the Satscard held against your device ($percentString)';
+  }
 
   @override
   String satscard_operation_dialog_incorrect_card_label(Object id) {

--- a/lib/generated/breez_translations_fr.dart
+++ b/lib/generated/breez_translations_fr.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart' as intl;
+
 import 'breez_translations.dart';
 
 /// The translations for French (`fr`).
@@ -344,6 +346,12 @@ class BreezTranslationsFr extends BreezTranslations {
 
   @override
   String get bottom_action_bar_buy_bitcoin => 'Acheter du bitcoin';
+
+  @override
+  String get bottom_action_bar_sweep_satscard => 'Sweep Satscard';
+
+  @override
+  String get bottom_action_bar_sweep_satscard_nfc_prompt => 'Please hold a Satscard against your device.';
 
   @override
   String bottom_action_bar_warning_balance_title(String balance) {
@@ -3312,6 +3320,12 @@ class BreezTranslationsFr extends BreezTranslations {
   String get satscard_dialog_cancel => 'CANCEL';
 
   @override
+  String get satscard_ios_success_label => 'Satscard was successfully scanned';
+
+  @override
+  String get satscard_ios_error_label => 'Unable to scan the Satscard';
+
+  @override
   String get satscard_error_invalid_title => 'Unknown Error';
 
   @override
@@ -3529,6 +3543,9 @@ class BreezTranslationsFr extends BreezTranslations {
   String get satscard_operation_dialog_cancel_label => 'CANCEL';
 
   @override
+  String get satscard_operation_dialog_content_ios_label => 'Tap the NFC icon to try again...';
+
+  @override
   String satscard_operation_dialog_present_satscards_label(Object id) {
     return 'Please hold the Satscard with the following ID against your device:\n$id';
   }
@@ -3541,6 +3558,14 @@ class BreezTranslationsFr extends BreezTranslations {
 
   @override
   String get satscard_operation_dialog_waiting_label => 'An incorrect spend code was previously entered. Please keep the Satscard held against your device';
+
+  @override
+  String satscard_operation_dialog_waiting_ios_label(double percent) {
+    final intl.NumberFormat percentNumberFormat = intl.NumberFormat.percentPattern(localeName);
+    final String percentString = percentNumberFormat.format(percent);
+
+    return 'An incorrect spend code was previously entered. Please keep the Satscard held against your device ($percentString)';
+  }
 
   @override
   String satscard_operation_dialog_incorrect_card_label(Object id) {

--- a/lib/generated/breez_translations_it.dart
+++ b/lib/generated/breez_translations_it.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart' as intl;
+
 import 'breez_translations.dart';
 
 /// The translations for Italian (`it`).
@@ -344,6 +346,12 @@ class BreezTranslationsIt extends BreezTranslations {
 
   @override
   String get bottom_action_bar_buy_bitcoin => 'Compra bitcoin';
+
+  @override
+  String get bottom_action_bar_sweep_satscard => 'Sweep Satscard';
+
+  @override
+  String get bottom_action_bar_sweep_satscard_nfc_prompt => 'Please hold a Satscard against your device.';
 
   @override
   String bottom_action_bar_warning_balance_title(String balance) {
@@ -3312,6 +3320,12 @@ class BreezTranslationsIt extends BreezTranslations {
   String get satscard_dialog_cancel => 'CANCEL';
 
   @override
+  String get satscard_ios_success_label => 'Satscard was successfully scanned';
+
+  @override
+  String get satscard_ios_error_label => 'Unable to scan the Satscard';
+
+  @override
   String get satscard_error_invalid_title => 'Unknown Error';
 
   @override
@@ -3529,6 +3543,9 @@ class BreezTranslationsIt extends BreezTranslations {
   String get satscard_operation_dialog_cancel_label => 'CANCEL';
 
   @override
+  String get satscard_operation_dialog_content_ios_label => 'Tap the NFC icon to try again...';
+
+  @override
   String satscard_operation_dialog_present_satscards_label(Object id) {
     return 'Please hold the Satscard with the following ID against your device:\n$id';
   }
@@ -3541,6 +3558,14 @@ class BreezTranslationsIt extends BreezTranslations {
 
   @override
   String get satscard_operation_dialog_waiting_label => 'An incorrect spend code was previously entered. Please keep the Satscard held against your device';
+
+  @override
+  String satscard_operation_dialog_waiting_ios_label(double percent) {
+    final intl.NumberFormat percentNumberFormat = intl.NumberFormat.percentPattern(localeName);
+    final String percentString = percentNumberFormat.format(percent);
+
+    return 'An incorrect spend code was previously entered. Please keep the Satscard held against your device ($percentString)';
+  }
 
   @override
   String satscard_operation_dialog_incorrect_card_label(Object id) {

--- a/lib/generated/breez_translations_pt.dart
+++ b/lib/generated/breez_translations_pt.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart' as intl;
+
 import 'breez_translations.dart';
 
 /// The translations for Portuguese (`pt`).
@@ -344,6 +346,12 @@ class BreezTranslationsPt extends BreezTranslations {
 
   @override
   String get bottom_action_bar_buy_bitcoin => 'Comprar Bitcoin';
+
+  @override
+  String get bottom_action_bar_sweep_satscard => 'Sweep Satscard';
+
+  @override
+  String get bottom_action_bar_sweep_satscard_nfc_prompt => 'Please hold a Satscard against your device.';
 
   @override
   String bottom_action_bar_warning_balance_title(String balance) {
@@ -3312,6 +3320,12 @@ class BreezTranslationsPt extends BreezTranslations {
   String get satscard_dialog_cancel => 'CANCEL';
 
   @override
+  String get satscard_ios_success_label => 'Satscard was successfully scanned';
+
+  @override
+  String get satscard_ios_error_label => 'Unable to scan the Satscard';
+
+  @override
   String get satscard_error_invalid_title => 'Unknown Error';
 
   @override
@@ -3529,6 +3543,9 @@ class BreezTranslationsPt extends BreezTranslations {
   String get satscard_operation_dialog_cancel_label => 'CANCEL';
 
   @override
+  String get satscard_operation_dialog_content_ios_label => 'Tap the NFC icon to try again...';
+
+  @override
   String satscard_operation_dialog_present_satscards_label(Object id) {
     return 'Please hold the Satscard with the following ID against your device:\n$id';
   }
@@ -3541,6 +3558,14 @@ class BreezTranslationsPt extends BreezTranslations {
 
   @override
   String get satscard_operation_dialog_waiting_label => 'An incorrect spend code was previously entered. Please keep the Satscard held against your device';
+
+  @override
+  String satscard_operation_dialog_waiting_ios_label(double percent) {
+    final intl.NumberFormat percentNumberFormat = intl.NumberFormat.percentPattern(localeName);
+    final String percentString = percentNumberFormat.format(percent);
+
+    return 'An incorrect spend code was previously entered. Please keep the Satscard held against your device ($percentString)';
+  }
 
   @override
   String satscard_operation_dialog_incorrect_card_label(Object id) {

--- a/lib/generated/breez_translations_sk.dart
+++ b/lib/generated/breez_translations_sk.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart' as intl;
+
 import 'breez_translations.dart';
 
 /// The translations for Slovak (`sk`).
@@ -344,6 +346,12 @@ class BreezTranslationsSk extends BreezTranslations {
 
   @override
   String get bottom_action_bar_buy_bitcoin => 'Kúpiť Bitcoin';
+
+  @override
+  String get bottom_action_bar_sweep_satscard => 'Sweep Satscard';
+
+  @override
+  String get bottom_action_bar_sweep_satscard_nfc_prompt => 'Please hold a Satscard against your device.';
 
   @override
   String bottom_action_bar_warning_balance_title(String balance) {
@@ -3312,6 +3320,12 @@ class BreezTranslationsSk extends BreezTranslations {
   String get satscard_dialog_cancel => 'CANCEL';
 
   @override
+  String get satscard_ios_success_label => 'Satscard was successfully scanned';
+
+  @override
+  String get satscard_ios_error_label => 'Unable to scan the Satscard';
+
+  @override
   String get satscard_error_invalid_title => 'Unknown Error';
 
   @override
@@ -3529,6 +3543,9 @@ class BreezTranslationsSk extends BreezTranslations {
   String get satscard_operation_dialog_cancel_label => 'CANCEL';
 
   @override
+  String get satscard_operation_dialog_content_ios_label => 'Tap the NFC icon to try again...';
+
+  @override
   String satscard_operation_dialog_present_satscards_label(Object id) {
     return 'Please hold the Satscard with the following ID against your device:\n$id';
   }
@@ -3541,6 +3558,14 @@ class BreezTranslationsSk extends BreezTranslations {
 
   @override
   String get satscard_operation_dialog_waiting_label => 'An incorrect spend code was previously entered. Please keep the Satscard held against your device';
+
+  @override
+  String satscard_operation_dialog_waiting_ios_label(double percent) {
+    final intl.NumberFormat percentNumberFormat = intl.NumberFormat.percentPattern(localeName);
+    final String percentString = percentNumberFormat.format(percent);
+
+    return 'An incorrect spend code was previously entered. Please keep the Satscard held against your device ($percentString)';
+  }
 
   @override
   String satscard_operation_dialog_incorrect_card_label(Object id) {

--- a/lib/generated/breez_translations_sv.dart
+++ b/lib/generated/breez_translations_sv.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart' as intl;
+
 import 'breez_translations.dart';
 
 /// The translations for Swedish (`sv`).
@@ -344,6 +346,12 @@ class BreezTranslationsSv extends BreezTranslations {
 
   @override
   String get bottom_action_bar_buy_bitcoin => 'Köp Bitcoin';
+
+  @override
+  String get bottom_action_bar_sweep_satscard => 'Sweep Satscard';
+
+  @override
+  String get bottom_action_bar_sweep_satscard_nfc_prompt => 'Please hold a Satscard against your device.';
 
   @override
   String bottom_action_bar_warning_balance_title(String balance) {
@@ -3312,6 +3320,12 @@ class BreezTranslationsSv extends BreezTranslations {
   String get satscard_dialog_cancel => 'CANCEL';
 
   @override
+  String get satscard_ios_success_label => 'Satscard was successfully scanned';
+
+  @override
+  String get satscard_ios_error_label => 'Unable to scan the Satscard';
+
+  @override
   String get satscard_error_invalid_title => 'Unknown Error';
 
   @override
@@ -3529,6 +3543,9 @@ class BreezTranslationsSv extends BreezTranslations {
   String get satscard_operation_dialog_cancel_label => 'CANCEL';
 
   @override
+  String get satscard_operation_dialog_content_ios_label => 'Tap the NFC icon to try again...';
+
+  @override
   String satscard_operation_dialog_present_satscards_label(Object id) {
     return 'Please hold the Satscard with the following ID against your device:\n$id';
   }
@@ -3541,6 +3558,14 @@ class BreezTranslationsSv extends BreezTranslations {
 
   @override
   String get satscard_operation_dialog_waiting_label => 'An incorrect spend code was previously entered. Please keep the Satscard held against your device';
+
+  @override
+  String satscard_operation_dialog_waiting_ios_label(double percent) {
+    final intl.NumberFormat percentNumberFormat = intl.NumberFormat.percentPattern(localeName);
+    final String percentString = percentNumberFormat.format(percent);
+
+    return 'An incorrect spend code was previously entered. Please keep the Satscard held against your device ($percentString)';
+  }
 
   @override
   String satscard_operation_dialog_incorrect_card_label(Object id) {

--- a/test/breez_translations_test.dart
+++ b/test/breez_translations_test.dart
@@ -986,6 +986,11 @@ void main() {
         expect(text.contains(cardId), true);
       });
 
+      test("satscard_operation_dialog_waiting_ios_label for ${locale.locale}", () {
+        final text = locale.satscard_operation_dialog_waiting_ios_label(waitPercentDouble);
+        expect(text.contains(waitPercent), true);
+      });
+
       test("satscard_operation_dialog_incorrect_card_label for ${locale.locale}", () {
         final text = locale.satscard_operation_dialog_incorrect_card_label(cardId);
         expect(text.contains(cardId), true);
@@ -1075,3 +1080,5 @@ const title = "aLongTitleToAvoidFalsePositive";
 const total = "aLongTotalToAvoidFalsePositive";
 const url = "aLongUrlToAvoidFalsePositive";
 const value = "aLongValueToAvoidFalsePositive";
+final waitPercent = RegExp(r"13\s?%");
+const waitPercentDouble = 0.127;


### PR DESCRIPTION
I added the test for the one new string which uses a placeholder.

The differences from Android:
- A "Sweep Satscard" option was added to the receive actions on the bottom action bar
  - This opens the NFC system prompt for iOS
  - A success or error message is shown on the NFC system prompt when scanning a Satscard on the home page
- A placeholder retry message is all that is required for SatscardOperationDialog on iOS
- Messages that are presented by SatscardOperationDialog on Android are instead routed through the NFC system prompt for iOS
  - On Android we present a progress indicator along with the waiting text but we can't on iOS so we include the progress in the text itself as a percentage