### PR TITLE
Add translations for lnurl pay domain

### DIFF
--- a/lib/app_bg.arb
+++ b/lib/app_bg.arb
@@ -374,6 +374,7 @@
   "payment_details_dialog_refresh_information": "Опреснете информацията",
   "payment_details_dialog_share_transaction": "Споделете хеша на трансакцията",
   "payment_details_dialog_share_lightning_address": "Светкавичен адрес",
+  "payment_details_dialog_share_lnurl_pay_domain": "Lightning Service",
   "payment_details_dialog_share_comment": "Коментар",
   "payment_details_dialog_copy_action": "Копирайте {title}",
   "@payment_details_dialog_copy_action": {

--- a/lib/app_cs.arb
+++ b/lib/app_cs.arb
@@ -374,6 +374,7 @@
   "payment_details_dialog_refresh_information": "Obnovit informace",
   "payment_details_dialog_share_transaction": "Sdílet hash transakce",
   "payment_details_dialog_share_lightning_address": "Lightning Adresa",
+  "payment_details_dialog_share_lnurl_pay_domain": "Lightning Service",
   "payment_details_dialog_share_comment": "Komentář",
   "payment_details_dialog_copy_action": "Kopírovat {title}",
   "@payment_details_dialog_copy_action": {

--- a/lib/app_de.arb
+++ b/lib/app_de.arb
@@ -374,6 +374,7 @@
   "payment_details_dialog_refresh_information": "Informationen aktualisieren",
   "payment_details_dialog_share_transaction": "Transaktions-Hash teilen",
   "payment_details_dialog_share_lightning_address": "Lightning-Adresse",
+  "payment_details_dialog_share_lnurl_pay_domain": "Lightning Service",
   "payment_details_dialog_share_comment": "Kommentar",
   "payment_details_dialog_copy_action": "Kopieren {title}",
   "@payment_details_dialog_copy_action": {

--- a/lib/app_el.arb
+++ b/lib/app_el.arb
@@ -374,6 +374,7 @@
   "payment_details_dialog_refresh_information": "Refresh Information",
   "payment_details_dialog_share_transaction": "Share Transaction Hash",
   "payment_details_dialog_share_lightning_address": "Lightning Address",
+  "payment_details_dialog_share_lnurl_pay_domain": "Lightning Service",
   "payment_details_dialog_share_comment": "Σχόλιο",
   "payment_details_dialog_copy_action": "Copy {title}",
   "@payment_details_dialog_copy_action": {

--- a/lib/app_en.arb
+++ b/lib/app_en.arb
@@ -374,6 +374,7 @@
   "payment_details_dialog_refresh_information": "Refresh Information",
   "payment_details_dialog_share_transaction": "Share Transaction Hash",
   "payment_details_dialog_share_lightning_address": "Lightning Address",
+  "payment_details_dialog_share_lnurl_pay_domain": "Lightning Service",
   "payment_details_dialog_share_comment": "Comment",
   "payment_details_dialog_copy_action": "Copy {title}",
   "@payment_details_dialog_copy_action": {

--- a/lib/app_es.arb
+++ b/lib/app_es.arb
@@ -374,6 +374,7 @@
   "payment_details_dialog_refresh_information": "Actualizar Información",
   "payment_details_dialog_share_transaction": "Compartir el Hash de Transacción",
   "payment_details_dialog_share_lightning_address": "Dirección Lightning",
+  "payment_details_dialog_share_lnurl_pay_domain": "Lightning Service",
   "payment_details_dialog_share_comment": "Comentario",
   "payment_details_dialog_copy_action": "Copiar {title}",
   "@payment_details_dialog_copy_action": {

--- a/lib/app_fi.arb
+++ b/lib/app_fi.arb
@@ -374,6 +374,7 @@
   "payment_details_dialog_refresh_information": "Päivitä näkymän tiedot",
   "payment_details_dialog_share_transaction": "Jaa tapahtuman Hash-koodi",
   "payment_details_dialog_share_lightning_address": "Lightning-osoite",
+  "payment_details_dialog_share_lnurl_pay_domain": "Lightning Service",
   "payment_details_dialog_share_comment": "Kommentti",
   "payment_details_dialog_copy_action": "Kopioi {title}",
   "@payment_details_dialog_copy_action": {

--- a/lib/app_fr.arb
+++ b/lib/app_fr.arb
@@ -374,6 +374,7 @@
   "payment_details_dialog_refresh_information": "Mettre à jour l'information",
   "payment_details_dialog_share_transaction": "Partager le hash de la transaction",
   "payment_details_dialog_share_lightning_address": "Adresse lightning",
+  "payment_details_dialog_share_lnurl_pay_domain": "Lightning Service",
   "payment_details_dialog_share_comment": "Commentaire",
   "payment_details_dialog_copy_action": "Copie {title}",
   "@payment_details_dialog_copy_action": {

--- a/lib/app_it.arb
+++ b/lib/app_it.arb
@@ -374,6 +374,7 @@
   "payment_details_dialog_refresh_information": "Aggiorna informazioni",
   "payment_details_dialog_share_transaction": "Condividi l'hash della transazione",
   "payment_details_dialog_share_lightning_address": "Lightning Address",
+  "payment_details_dialog_share_lnurl_pay_domain": "Lightning Service",
   "payment_details_dialog_share_comment": "Commento",
   "payment_details_dialog_copy_action": "Copia {title}",
   "@payment_details_dialog_copy_action": {

--- a/lib/app_pt.arb
+++ b/lib/app_pt.arb
@@ -374,6 +374,7 @@
   "payment_details_dialog_refresh_information": "Atualizar informação",
   "payment_details_dialog_share_transaction": "Compartilhar o hash da transação",
   "payment_details_dialog_share_lightning_address": "Endereço Relâmpago",
+  "payment_details_dialog_share_lnurl_pay_domain": "Lightning Service",
   "payment_details_dialog_share_comment": "Comentário",
   "payment_details_dialog_copy_action": "Copiar {title}",
   "@payment_details_dialog_copy_action": {

--- a/lib/app_sk.arb
+++ b/lib/app_sk.arb
@@ -374,6 +374,7 @@
   "payment_details_dialog_refresh_information": "Aktualizovať informácie",
   "payment_details_dialog_share_transaction": "Zdieľať hash transakcie",
   "payment_details_dialog_share_lightning_address": "Lightning adresa",
+  "payment_details_dialog_share_lnurl_pay_domain": "Lightning Service",
   "payment_details_dialog_share_comment": "Komentovať",
   "payment_details_dialog_copy_action": "Kopírovať {title}",
   "@payment_details_dialog_copy_action": {

--- a/lib/app_sv.arb
+++ b/lib/app_sv.arb
@@ -374,6 +374,7 @@
   "payment_details_dialog_refresh_information": "Uppdatera information",
   "payment_details_dialog_share_transaction": "Dela transaktions hash",
   "payment_details_dialog_share_lightning_address": "Lightning Adress",
+  "payment_details_dialog_share_lnurl_pay_domain": "Lightning Service",
   "payment_details_dialog_share_comment": "Kommentera",
   "payment_details_dialog_copy_action": "Kopiera {title}",
   "@payment_details_dialog_copy_action": {

--- a/lib/generated/breez_translations.dart
+++ b/lib/generated/breez_translations.dart
@@ -875,6 +875,12 @@ abstract class BreezTranslations {
   /// **'Lightning Address'**
   String get payment_details_dialog_share_lightning_address;
 
+  /// No description provided for @payment_details_dialog_share_lnurl_pay_domain.
+  ///
+  /// In en, this message translates to:
+  /// **'Lightning Service'**
+  String get payment_details_dialog_share_lnurl_pay_domain;
+
   /// No description provided for @payment_details_dialog_share_comment.
   ///
   /// In en, this message translates to:

--- a/lib/generated/breez_translations_bg.dart
+++ b/lib/generated/breez_translations_bg.dart
@@ -432,6 +432,9 @@ class BreezTranslationsBg extends BreezTranslations {
   String get payment_details_dialog_share_lightning_address => 'Светкавичен адрес';
 
   @override
+  String get payment_details_dialog_share_lnurl_pay_domain => 'Lightning Service';
+
+  @override
   String get payment_details_dialog_share_comment => 'Коментар';
 
   @override

--- a/lib/generated/breez_translations_cs.dart
+++ b/lib/generated/breez_translations_cs.dart
@@ -432,6 +432,9 @@ class BreezTranslationsCs extends BreezTranslations {
   String get payment_details_dialog_share_lightning_address => 'Lightning Adresa';
 
   @override
+  String get payment_details_dialog_share_lnurl_pay_domain => 'Lightning Service';
+
+  @override
   String get payment_details_dialog_share_comment => 'Komentář';
 
   @override

--- a/lib/generated/breez_translations_de.dart
+++ b/lib/generated/breez_translations_de.dart
@@ -432,6 +432,9 @@ class BreezTranslationsDe extends BreezTranslations {
   String get payment_details_dialog_share_lightning_address => 'Lightning-Adresse';
 
   @override
+  String get payment_details_dialog_share_lnurl_pay_domain => 'Lightning Service';
+
+  @override
   String get payment_details_dialog_share_comment => 'Kommentar';
 
   @override

--- a/lib/generated/breez_translations_el.dart
+++ b/lib/generated/breez_translations_el.dart
@@ -432,6 +432,9 @@ class BreezTranslationsEl extends BreezTranslations {
   String get payment_details_dialog_share_lightning_address => 'Lightning Address';
 
   @override
+  String get payment_details_dialog_share_lnurl_pay_domain => 'Lightning Service';
+
+  @override
   String get payment_details_dialog_share_comment => 'Σχόλιο';
 
   @override

--- a/lib/generated/breez_translations_en.dart
+++ b/lib/generated/breez_translations_en.dart
@@ -432,6 +432,9 @@ class BreezTranslationsEn extends BreezTranslations {
   String get payment_details_dialog_share_lightning_address => 'Lightning Address';
 
   @override
+  String get payment_details_dialog_share_lnurl_pay_domain => 'Lightning Service';
+
+  @override
   String get payment_details_dialog_share_comment => 'Comment';
 
   @override

--- a/lib/generated/breez_translations_es.dart
+++ b/lib/generated/breez_translations_es.dart
@@ -432,6 +432,9 @@ class BreezTranslationsEs extends BreezTranslations {
   String get payment_details_dialog_share_lightning_address => 'Dirección Lightning';
 
   @override
+  String get payment_details_dialog_share_lnurl_pay_domain => 'Lightning Service';
+
+  @override
   String get payment_details_dialog_share_comment => 'Comentario';
 
   @override

--- a/lib/generated/breez_translations_fi.dart
+++ b/lib/generated/breez_translations_fi.dart
@@ -432,6 +432,9 @@ class BreezTranslationsFi extends BreezTranslations {
   String get payment_details_dialog_share_lightning_address => 'Lightning-osoite';
 
   @override
+  String get payment_details_dialog_share_lnurl_pay_domain => 'Lightning Service';
+
+  @override
   String get payment_details_dialog_share_comment => 'Kommentti';
 
   @override

--- a/lib/generated/breez_translations_fr.dart
+++ b/lib/generated/breez_translations_fr.dart
@@ -432,6 +432,9 @@ class BreezTranslationsFr extends BreezTranslations {
   String get payment_details_dialog_share_lightning_address => 'Adresse lightning';
 
   @override
+  String get payment_details_dialog_share_lnurl_pay_domain => 'Lightning Service';
+
+  @override
   String get payment_details_dialog_share_comment => 'Commentaire';
 
   @override

--- a/lib/generated/breez_translations_it.dart
+++ b/lib/generated/breez_translations_it.dart
@@ -432,6 +432,9 @@ class BreezTranslationsIt extends BreezTranslations {
   String get payment_details_dialog_share_lightning_address => 'Lightning Address';
 
   @override
+  String get payment_details_dialog_share_lnurl_pay_domain => 'Lightning Service';
+
+  @override
   String get payment_details_dialog_share_comment => 'Commento';
 
   @override

--- a/lib/generated/breez_translations_pt.dart
+++ b/lib/generated/breez_translations_pt.dart
@@ -432,6 +432,9 @@ class BreezTranslationsPt extends BreezTranslations {
   String get payment_details_dialog_share_lightning_address => 'Endereço Relâmpago';
 
   @override
+  String get payment_details_dialog_share_lnurl_pay_domain => 'Lightning Service';
+
+  @override
   String get payment_details_dialog_share_comment => 'Comentário';
 
   @override

--- a/lib/generated/breez_translations_sk.dart
+++ b/lib/generated/breez_translations_sk.dart
@@ -432,6 +432,9 @@ class BreezTranslationsSk extends BreezTranslations {
   String get payment_details_dialog_share_lightning_address => 'Lightning adresa';
 
   @override
+  String get payment_details_dialog_share_lnurl_pay_domain => 'Lightning Service';
+
+  @override
   String get payment_details_dialog_share_comment => 'Komentovať';
 
   @override

--- a/lib/generated/breez_translations_sv.dart
+++ b/lib/generated/breez_translations_sv.dart
@@ -432,6 +432,9 @@ class BreezTranslationsSv extends BreezTranslations {
   String get payment_details_dialog_share_lightning_address => 'Lightning Adress';
 
   @override
+  String get payment_details_dialog_share_lnurl_pay_domain => 'Lightning Service';
+
+  @override
   String get payment_details_dialog_share_comment => 'Kommentera';
 
   @override


### PR DESCRIPTION
Adds "Lightning Service" label to be displayed on payment detail dialog for LNURL payments that were not made to a lightning address, e.g.; **Lightning Service**: livingroomofsatoshi.com